### PR TITLE
Fixes initialization where colors weren't being applied to shape

### DIFF
--- a/C4UI/C4Shape.swift
+++ b/C4UI/C4Shape.swift
@@ -70,7 +70,7 @@ public class C4Shape: C4View {
     */
     convenience public init(frame: C4Rect) {
         self.init()
-        self.view = ShapeView(frame: CGRect(frame))
+        self.view.frame = CGRect(frame)
     }
     
     public override init() {


### PR DESCRIPTION
init(frame:) was recreating its ShapeView after it was already
initialized, this change applies the frame variable to the view after
it is already created