### PR TITLE
Changes order of setting backgroundColor in viewDidLoad()

### DIFF
--- a/C4/UI/C4CanvasController.swift
+++ b/C4/UI/C4CanvasController.swift
@@ -29,8 +29,8 @@ public class C4CanvasController : UIViewController {
     */
     public override func viewDidLoad() {
         C4ShapeLayer.disableActions = true
-        self.setup()
         canvas.backgroundColor = C4Grey
+        self.setup()
         C4ShapeLayer.disableActions = false
     }
 


### PR DESCRIPTION
Previously, the controller would set the default background to C4Grey
AFTER setup was complete, preventing developer from being able to set
background color during setup.