### PR TITLE
Makes corner size = 0 if width of shape < default corner size

### DIFF
--- a/C4/UI/C4Rectangle.swift
+++ b/C4/UI/C4Rectangle.swift
@@ -51,6 +51,9 @@ public class C4Rectangle: C4Shape {
     */
     convenience public init(frame: C4Rect) {
         self.init()
+        if frame.size.width <= corner.width * 2.0 {
+            corner = C4Size()
+        }
         view.frame = CGRect(frame)
         updatePath()
     }


### PR DESCRIPTION
Was crashing in situations like : `C4Rectangle(frame: C4Rect(0,0,5,5))`
where the width was smaller than the default corner size of (8,8)