### PR TITLE
Adds passing of autoreverse and repeat options to calayer animations

### DIFF
--- a/C4/UI/C4ShapeLayer.swift
+++ b/C4/UI/C4ShapeLayer.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 C4. All rights reserved.
 
 import QuartzCore
-
+import UIKit
 /**
 Extension for CAShapeLayer that allows overriding the actions for specific properties.
 */
@@ -15,6 +15,7 @@ public class C4ShapeLayer: CAShapeLayer {
         
         if key == "lineWidth" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.lineWidth
             return animation;
         }

--- a/C4/UI/C4ShapeLayer.swift
+++ b/C4/UI/C4ShapeLayer.swift
@@ -21,34 +21,49 @@ public class C4ShapeLayer: CAShapeLayer {
         }
         else if key == "strokeEnd" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.strokeEnd
             return animation;
         }
         else if key == "strokeStart" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.strokeStart
             return animation;
         }
         else if key == "strokeColor" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.strokeColor
             return animation;
         }
         else if key == "path" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.path
             return animation;
         }
         else if key == "fillColor" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.fillColor
             return animation;
         } else if key == "lineDashPhase" {
             let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
             animation.fromValue = self.lineDashPhase
             return animation;
         }
         
         return super.actionForKey(key)
+    }
+}
+
+extension CABasicAnimation {
+    public func configureOptions() {
+        self.autoreverses = currentOptions.contains(UIViewAnimationOptions.Autoreverse)
+        self.repeatCount = currentRepeatCount
+        self.fillMode = kCAFillModeBoth
+        self.removedOnCompletion = false
     }
 }

--- a/C4/UI/C4ViewAnimation.swift
+++ b/C4/UI/C4ViewAnimation.swift
@@ -20,6 +20,9 @@
 import Foundation
 import UIKit
 
+public var currentOptions : UIViewAnimationOptions = UIViewAnimationOptions.BeginFromCurrentState
+public var currentRepeatCount : Float = 0.0
+
 public class C4ViewAnimation : C4Animation {
     public var delay: NSTimeInterval = 0
     
@@ -84,6 +87,8 @@ public class C4ViewAnimation : C4Animation {
         }
         
         UIView.animateWithDuration(duration, delay: delay, options: options, animations: {
+            currentOptions = options
+            currentRepeatCount = Float(self.repeatCount)
             UIView.setAnimationRepeatCount(Float(self.repeatCount))
             CATransaction.begin()
             CATransaction.setAnimationDuration(self.duration)
@@ -93,6 +98,7 @@ public class C4ViewAnimation : C4Animation {
             }
             self.animations()
             CATransaction.commit()
+            currentOptions = UIViewAnimationOptions.BeginFromCurrentState
         }, completion:nil)
     }
 }


### PR DESCRIPTION
Works with the following situation (which has multiple animations happening): 

```
class ViewController: C4CanvasController {

    override func setup() {
        let c = C4Circle(center: canvas.center, radius: 50)
        canvas.add(c)

        let anim = C4ViewAnimation(duration: 2.5) {
            c.lineWidth = 20.0
        }

        anim.autoreverses = true

        delay(0.5) {
            anim.animate()
        }

        let anim2 = C4ViewAnimation(duration: 0.25) {
            c.strokeColor = red
        }
        anim2.autoreverses = true
        anim2.repeats = true
        delay(1.0) {
            anim2.animate()
        }
    }
}
```