### PR TITLE
Adds close() to C4Polygon

### DIFF
--- a/C4/UI/C4Polygon.swift
+++ b/C4/UI/C4Polygon.swift
@@ -96,4 +96,11 @@ public class C4Polygon: C4Shape {
             adjustToFitPath()
         }
     }
+    
+    public func close() {
+        let p = path
+        p?.closeSubpath()
+        self.path = p
+        adjustToFitPath()
+    }
 }


### PR DESCRIPTION
Polygons are the only shape that can be open-ended, if needed calling
close() will apply .closeSubpath() to the internal path of the shape.