### PR TITLE
C4LineCenterFix

### DIFF
--- a/C4/UI/C4Line.swift
+++ b/C4/UI/C4Line.swift
@@ -63,6 +63,17 @@ public class C4Line: C4Polygon {
         }
     }
 
+    public override var center : C4Point {
+        get {
+            return C4Point(view.center)
+        }
+        set {
+            let diff = newValue - self.center
+            let newA = a + diff
+            let newB = b + diff
+            self.points = [newA, newB]
+        }
+    }
 
     /**
     Initializes a new C4Polygon using the specified array of points.

--- a/C4/UI/C4Line.swift
+++ b/C4/UI/C4Line.swift
@@ -75,6 +75,19 @@ public class C4Line: C4Polygon {
         }
     }
 
+
+    public override var origin : C4Point {
+        get {
+            return C4Point(view.frame.origin)
+        }
+        set {
+            let diff = newValue - self.origin
+            let newA = a + diff
+            let newB = b + diff
+            self.points = [newA, newB]
+        }
+    }
+
     /**
     Initializes a new C4Polygon using the specified array of points.
 


### PR DESCRIPTION
Properly adjusts {a,b} when setting center or origin of a C4Line.

Fixes #368