### PR TITLE
Checks anchorPoint prior to setting endPoints for origin/center

### DIFF
--- a/C4/UI/C4Line.swift
+++ b/C4/UI/C4Line.swift
@@ -52,10 +52,14 @@ public class C4Line: C4Polygon {
             return C4Point(view.center)
         }
         set {
-            let diff = newValue - center
-            batchUpdates() {
-                self.endPoints.0 += diff
-                self.endPoints.1 += diff
+            if self.anchorPoint == C4Point(0.5,0.5) {
+                let diff = newValue - center
+                batchUpdates() {
+                    self.endPoints.0 += diff
+                    self.endPoints.1 += diff
+                }
+            } else {
+                view.center = CGPoint(newValue)
             }
         }
     }
@@ -68,10 +72,14 @@ public class C4Line: C4Polygon {
             return C4Point(view.frame.origin)
         }
         set {
-            let diff = newValue - origin
-            batchUpdates() {
-                self.endPoints.0 += diff
-                self.endPoints.1 += diff
+            if self.anchorPoint == C4Point(0.5,0.5) {
+                let diff = newValue - origin
+                batchUpdates() {
+                    self.endPoints.0 += diff
+                    self.endPoints.1 += diff
+                }
+            } else {
+                view.center = CGPoint(newValue)
             }
         }
     }


### PR DESCRIPTION
This fix checks to see if the anchor point of the receiver has its
default value. If not, this implies that the developer has changed the
position of the anchorPoint. In such a situation it is not easy to
determine where the endPoints should actually go), so we default to
changing the center of the view rather than updating the endPoints.