### PR TITLE
Makes LayerView a subclass of NativeView

### DIFF
--- a/C4/Core/C4OS.swift
+++ b/C4/Core/C4OS.swift
@@ -39,7 +39,7 @@ public extension UIView {
 }
 
 /// In UIKit all views have layers, but this class is here for consistency with OS X
-public class LayerView : UIView {
+public class LayerView : NativeView {
 }
 
 // MARK: - AppKit
@@ -110,7 +110,7 @@ public extension NSView {
 }
 
 /// Hosted-layer NSView
-public class LayerView : NSView {
+public class LayerView : NativeView {
     public var backgroundColor: NSColor? {
         didSet {
             needsDisplay = true


### PR DESCRIPTION
Fixes #574

This fix also requires setting the view of the main controller in
Main.Storyboard to a LayerView (in whichever project you’re adding C4
framework to) and having that view require a CALayer