### PR TITLE
Adds a test scheme

### DIFF
--- a/C4iOS.xcodeproj/project.pbxproj
+++ b/C4iOS.xcodeproj/project.pbxproj
@@ -7,9 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1F8252CC1BB3C65E0090E98A /* C4Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8252CB1BB3C65E0090E98A /* C4Timer.swift */; settings = {ASSET_TAGS = (); }; };
-		61BBAF631BC372BD00A03FD0 /* C4StoredAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBAF621BC372BD00A03FD0 /* C4StoredAnimation.swift */; settings = {ASSET_TAGS = (); }; };
-		61BBAF651BC38C1200A03FD0 /* C4View+KeyValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBAF641BC38C1200A03FD0 /* C4View+KeyValues.swift */; settings = {ASSET_TAGS = (); }; };
+		1F8252CC1BB3C65E0090E98A /* C4Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8252CB1BB3C65E0090E98A /* C4Timer.swift */; };
+		1FEE86CC1C057954003FE148 /* C4.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 614F824319DB5ED3001DF1D4 /* C4.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61BBAF631BC372BD00A03FD0 /* C4StoredAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBAF621BC372BD00A03FD0 /* C4StoredAnimation.swift */; };
+		61BBAF651BC38C1200A03FD0 /* C4View+KeyValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBAF641BC38C1200A03FD0 /* C4View+KeyValues.swift */; };
 		A94E3BD419E0E9390039A9C4 /* C4.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614F824319DB5ED3001DF1D4 /* C4.framework */; };
 		A96F4F451B538330002B3A46 /* C4ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9596D401A054B4F0023323D /* C4ColorTests.swift */; };
 		A96F4F461B538330002B3A46 /* C4MathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9596D411A054B4F0023323D /* C4MathTests.swift */; };
@@ -108,6 +109,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		1FEE86CB1C057947003FE148 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				1FEE86CC1C057954003FE148 /* C4.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A96F50821B538650002B3A46 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -422,6 +433,7 @@
 				614F824A19DB5ED4001DF1D4 /* Sources */,
 				614F824B19DB5ED4001DF1D4 /* Frameworks */,
 				614F824C19DB5ED4001DF1D4 /* Resources */,
+				1FEE86CB1C057947003FE148 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2012 Travis Kirton
+Copyright © 2012-2016 C4
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Travis-CI continues to fail with the following error:

```
Failures:
0) C4Tests-OSX (C4Tests-OSX.xctest)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━������━━━━━━━━━━━━━━━━━━━━━━━━
Failed to query the list of test cases in the test bundle:
dlopen(/Users/travis/Library/Developer/Xcode/DerivedData/C4iOS-cwsldhiwz
rijlbenlzhunpagifkw/Build/Products/Debug/C4Tests-OSX.xctest/Contents/Mac
OS/C4Tests-OSX, 1): Library not loaded:
/System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
Referenced from:
/Users/travis/Library/Developer/Xcode/DerivedData/C4iOS-cwsldhiwzrijlben
lzhunpagifkw/Build/Products/Debug/C4.framework/Versions/A/C4
Reason: image not found
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

From their github page
(https://github.com/travis-ci/travis-ci/issues/3001), I found and
applied this possible solution:

https://github.com/facebook/xctool/issues/415#issuecomment-62013753