### PR TITLE
Adds gradientFill to C4Shape

### DIFF
--- a/C4/UI/C4Image.swift
+++ b/C4/UI/C4Image.swift
@@ -78,6 +78,13 @@ public class C4Image: C4View, NSCopying {
 
     //MARK: Initializers
     
+    /// Initializes an empty C4Image
+    public override init() {
+        super.init()
+        let uiimage = UIImage()
+        self.view = ImageView(image: uiimage)
+    }
+
     /// Initializes a new C4Image using the specified filename from the bundle (i.e. your project), it will also grab images
     /// from the web if the filename starts with http.
     ///

--- a/C4/UI/C4ShapeLayer.swift
+++ b/C4/UI/C4ShapeLayer.swift
@@ -81,6 +81,11 @@ public class C4ShapeLayer: CAShapeLayer {
             animation.configureOptions()
             animation.fromValue = self.lineDashPhase
             return animation;
+        } else if key == "contents" {
+            let animation = CABasicAnimation(keyPath: key)
+            animation.configureOptions()
+            animation.fromValue = self.contents
+            return animation;
         }
         
         return super.actionForKey(key)


### PR DESCRIPTION
Includes:
- Initializer for C4Shape(shape: C4Shape)
- Initializer for C4Image() //empty image
- Initializing contents of C4Shape to a {1,1} clear image, otherwise
animating between nil and cgimageref doesn’t animate

Fixes: #592