### PR TITLE
Changes Foundation's delay to wait

### DIFF
--- a/C4/Core/Foundation.swift
+++ b/C4/Core/Foundation.swift
@@ -61,11 +61,11 @@ public func CGRectMakeFromPoints(points: [CGPoint]) -> CGRect {
 ///
 /// - parameter delay:  The amount of time in seconds to wait before executing the block of code.
 /// - parameter action: A block of code to perform after the delay.
-public func delay(delay: Double, action: ()->()) {
+public func wait(seconds: Double, action: ()->()) {
     dispatch_after(
         dispatch_time(
             DISPATCH_TIME_NOW,
-            Int64(delay * Double(NSEC_PER_SEC))
+            Int64(seconds * Double(NSEC_PER_SEC))
         ),
         dispatch_get_main_queue(), action)
 }

--- a/C4/UI/ScreenRecorder.swift
+++ b/C4/UI/ScreenRecorder.swift
@@ -42,7 +42,7 @@ public class ScreenRecorder: NSObject, RPPreviewViewControllerDelegate {
 
     public func start(duration: Double) {
         start()
-        delay(duration) {
+        wait(duration) {
             self.stop()
         }
     }

--- a/C4/UI/ViewAnimation.swift
+++ b/C4/UI/ViewAnimation.swift
@@ -138,7 +138,7 @@ public class ViewAnimation: Animation {
         let disable = ShapeLayer.disableActions
         ShapeLayer.disableActions = false
 
-        C4.delay(delay) {
+        wait(delay) {
             if let spring = self.spring {
                 self.animateWithSpring(spring)
             } else {


### PR DESCRIPTION
This solves a conflict that arises when there is no namespace, i.e. C4 files existing directly in a project rather than as a linked framework. 

This solves the following issues:

1. Current issues with with installer – makes possible to have non-framework project structure
2. Preserves `delay` property in `ViewAnimation` which allows for better consistency with `UIView` animation api