### PR TITLE
Makes init() public for Circle and Polygon

### DIFF
--- a/C4/UI/Circle.swift
+++ b/C4/UI/Circle.swift
@@ -23,6 +23,9 @@ import CoreGraphics
 ///Circle is a concrete subclass of Ellipse that has a special initialzer that creates a uniform ellipse.
 public class Circle: Ellipse {
 
+    public override init() {
+        super.init()
+    }
     /// Creates a circle.
     ///
     /// ````

--- a/C4/UI/Polygon.swift
+++ b/C4/UI/Polygon.swift
@@ -43,7 +43,7 @@ public class Polygon: Shape {
     }
 
     ///  Initializes a default Polygon.
-    override init() {
+    public override init() {
         self.points = []
         super.init()
         fillColor = clear


### PR DESCRIPTION
As a user I want to be able to create an empty Polygon, rather than an empty Shape. I want this because I can take advantage of how Polygon initializes differently than Shape.

```
func continuousLines() {
    let p = Path()
    let poly = Polygon()
    canvas.add(poly)
    canvas.addPanGestureRecognizer { location, translation, velocity, state in
        if state == .Began {
            p.moveToPoint(location)
        } else {
            p.addLineToPoint(location)
        }
        poly.path = p
    }
}
```

Same logic for Circle.