### PR TITLE
Updates initializers, allowing for subclassing outside of framework

### DIFF
--- a/C4/UI/Image.swift
+++ b/C4/UI/Image.swift
@@ -47,6 +47,10 @@ public class Image: View, NSCopying {
         self.view = ImageView(image: uiimage)
     }
 
+    public override init(frame: Rect) {
+        super.init(frame: frame)
+    }
+
     /// Initializes a new Image using the specified filename from the bundle (i.e. your project), it will also grab images
     /// from the web if the filename starts with http.
     /// ````

--- a/C4/UI/Movie.swift
+++ b/C4/UI/Movie.swift
@@ -166,7 +166,7 @@ public class Movie: View {
     /// Initializes a new Movie using the specified frame.
     ///
     /// - parameter frame:	The frame of the new movie object.
-    public init(frame: Rect) {
+    public override init(frame: Rect) {
         super.init()
         self.view = MovieView(frame: CGRect(frame))
     }

--- a/C4/UI/Rectangle.swift
+++ b/C4/UI/Rectangle.swift
@@ -49,13 +49,17 @@ public class Rectangle: Shape {
     /// ````
     ///
     /// - parameter frame: A Rect whose dimensions are used to construct the Rectangle.
-    convenience public init(frame: Rect) {
-        self.init()
+    public init(frame: Rect) {
+        super.init()
         if frame.size.width <= corner.width * 2.0 || frame.size.height <= corner.width / 2.0 {
             corner = Size()
         }
         view.frame = CGRect(frame)
         updatePath()
+    }
+
+    public override init() {
+        super.init()
     }
 
     override func updatePath() {

--- a/C4/UI/Shape.swift
+++ b/C4/UI/Shape.swift
@@ -52,7 +52,7 @@ public class Shape: View {
     }
 
     ///  Initializes an empty Shape.
-    override init() {
+    public override init() {
         super.init()
 
         self.view = ShapeView()

--- a/C4/UI/View.swift
+++ b/C4/UI/View.swift
@@ -84,8 +84,8 @@ public class View: NSObject {
     /// canvas.add(v)
     /// ````
     /// - parameter frame: A Rect, which describes the view’s location and size in its superview’s coordinate system.
-    convenience public init(frame: Rect) {
-        self.init()
+    public init(frame: Rect) {
+        super.init()
         self.view.frame = CGRect(frame)
     }
 


### PR DESCRIPTION
Fixes: #609 

Tested with the following:
> Examples for each class commented above the subclass declaration.

```
//let m = MyView(frame: Rect(0, 0, 100, 100))
//m.backgroundColor = C4Blue
//canvas.add(m)
class MyView: View {
    override init() {
        super.init()
    }

    override init(frame: Rect) {
        super.init(frame: frame)
    }

    override init(view: UIView) {
        super.init(view: view)
    }
}

//let p = Path()
//p.moveToPoint(Point())
//p.addLineToPoint(Point(100,100))
//
//let ms = MyShape()
//ms.path = p
//ms.adjustToFitPath()
//canvas.add(ms)
//
//let ms = MyShape(p)
class MyShape: Shape {
}

//let mr = MyRectangle(frame: Rect(0, 0, 100, 100))
//canvas.add(mr)
public class MyRectangle: Rectangle {
    public override init() {
        super.init()
    }
}

//let mi = MyImage("chop")!
//let dotScreen = DotScreen()
//mi.apply(dotScreen)
//canvas.add(mi)
//
//let mi = MyImage(frame: Rect(0, 0, 100, 100))
//mi.generate(Checkerboard())
//canvas.add(mi)
class MyImage: Image {
    override init() {
        super.init()
    }

    override init(frame: Rect) {
        super.init(frame: frame)
    }
}

//let mm = MyMovie("halo.mp4")
//canvas.add(mm)
//mm?.play()
class MyMovie: Movie {
}

//let ma = MyAudioPlayer("C4Loop.aif")
//ma?.play()
class MyAudioPlayer: AudioPlayer {

}
```