### PR TITLE
translationInView(view.superview)

### DIFF
--- a/C4/UI/UIGestureRecognizer+Closure.swift
+++ b/C4/UI/UIGestureRecognizer+Closure.swift
@@ -139,7 +139,7 @@ extension UIPanGestureRecognizer {
     public var translation: Vector {
         get {
             if let view = referenceView {
-                return Vector(translationInView(view))
+                return Vector(translationInView(view.superview))
             }
             return Vector()
         }


### PR DESCRIPTION
changed to view.superview in order to translate a rotated view properly. 