### PR TITLE
translationInView to view.superview

### DIFF
--- a/C4/UI/UIGestureRecognizer+Closure.swift
+++ b/C4/UI/UIGestureRecognizer+Closure.swift
@@ -139,7 +139,7 @@ extension UIPanGestureRecognizer {
     public var translation: Vector {
         get {
             if let view = referenceView {
-                return Vector(translationInView(view))
+                return Vector(translationInView(view.superview))
             }
             return Vector()
         }


### PR DESCRIPTION
When a view is rotated this translationInView does not function as intended. The translation does not follow the location of gesture. Instead changing to view.superview allows rotated views and non-rotated to translate as expected.