### PR TITLE
use map instead of appending

### DIFF
--- a/C4/UI/Gradient.swift
+++ b/C4/UI/Gradient.swift
@@ -44,19 +44,13 @@ public class Gradient: View {
     public var colors: [Color] {
         get {
             if let cgcolors = gradientLayer.colors as? [CGColorRef] {
-                var array = [Color]()
-                for c in cgcolors {
-                    array.append(Color(c))
-                }
-                return array
+                return cgcolors.map{ c in Color(c) }
             }
             return [C4Blue, C4Pink]
         } set {
             assert(newValue.count >= 2, "colors must have at least 2 elements")
-            var cgcolors = [CGColorRef]()
-            for c in newValue {
-                cgcolors.append(c.CGColor)
-            }
+            
+            let cgcolors = newValue.map{c in c.CGColor}
             self.gradientLayer.colors = cgcolors
         }
     }
@@ -71,10 +65,7 @@ public class Gradient: View {
             }
             return []
         } set {
-            var numbers = [NSNumber]()
-            for n in newValue {
-                numbers.append(n)
-            }
+            let numbers = newValue.map{ number in NSNumber(double: number) }
             gradientLayer.locations = numbers
         }
     }


### PR DESCRIPTION
Refactor code like

```swift
var newArray = [someType]()
for c in oldArray {
    newArray.append(someTransform(c))
}
```

to

```swift
let newArray = oldArray.map{ c in someTransform(c) }
```

If you use this statement, C4 code works more effectively, and code looks clean.