### PR TITLE
use iterating instead of Integer indexing

### DIFF
--- a/C4/UI/Polygon.swift
+++ b/C4/UI/Polygon.swift
@@ -70,9 +70,9 @@ public class Polygon: Shape {
         fillColor = clear
 
         let path = Path()
-        path.moveToPoint(points[0])
-        for i in 1..<points.count {
-            path.addLineToPoint(points[i])
+        path.moveToPoint(points.first!)
+        for point in points.dropFirst() {
+            path.addLineToPoint(point)
         }
         self.path = path
 
@@ -88,10 +88,9 @@ public class Polygon: Shape {
     override func updatePath() {
         if points.count > 1 {
             let p = Path()
-            p.moveToPoint(points[0])
-
-            for i in 1..<points.count {
-                p.addLineToPoint(points[i])
+            p.moveToPoint(points.first!)
+            for point in points.dropFirst() {
+                p.addLineToPoint(point)
             }
 
             path = p

--- a/C4/UI/Shape+Creation.swift
+++ b/C4/UI/Shape+Creation.swift
@@ -67,8 +67,8 @@ extension Shape {
             newPath = Path()
         }
 
-        if !points.isEmpty {
-            newPath!.moveToPoint(points[0])
+        if let firstPoint = points.first {
+            newPath!.moveToPoint(firstPoint)
         }
         for point in points {
             newPath!.addLineToPoint(point)
@@ -95,8 +95,8 @@ extension Shape {
             path = Path()
         }
 
-        if newPath!.currentPoint != points[0] {
-            newPath!.moveToPoint(points[0])
+        if newPath!.currentPoint != points.first! {
+            newPath!.moveToPoint(points.first!)
         }
         newPath!.addLineToPoint(points[1])
         path = newPath
@@ -121,10 +121,10 @@ extension Shape {
             path = Path()
         }
 
-        if newPath!.currentPoint != points[0] {
-            newPath!.moveToPoint(points[0])
+        if newPath!.currentPoint != points.first! {
+            newPath!.moveToPoint(points.first!)
         }
-        newPath!.addCurveToPoint(points[1], control1: controls[0], control2: controls[1])
+        newPath!.addCurveToPoint(points[1], control1: controls.first!, control2: controls[1])
         path = newPath
         adjustToFitPath()
     }

--- a/C4/UI/TextShape.swift
+++ b/C4/UI/TextShape.swift
@@ -103,12 +103,12 @@ public class TextShape: Shape {
         let textPath = CGPathCreateMutable()
         var invert = CGAffineTransformMakeScale(1, -1)
         var origin = CGPoint()
-        for i in 0..<glyphs.count {
-            let glyphPath = CTFontCreatePathForGlyph(ctfont!, glyphs[i], &invert)
+        for (advance, glyph) in zip(advances, glyphs) {
+            let glyphPath = CTFontCreatePathForGlyph(ctfont!, glyph, &invert)
             var translation = CGAffineTransformMakeTranslation(origin.x, origin.y)
             CGPathAddPath(textPath, &translation, glyphPath)
-            origin.x += CGFloat(advances[i].width)
-            origin.y += CGFloat(advances[i].height)
+            origin.x += CGFloat(advance.width)
+            origin.y += CGFloat(advance.height)
         }
         return Path(path: textPath)
     }


### PR DESCRIPTION
I think, if you use ".count" method, swift will see though the sequence and count elements.

So, we should use for-iteration or .first/.last property instead of integer indexing.

You may think ".dropFirst()" method mutate structure because of the name, but ".removeFirst()" method is the function, and .dropFirst() method just returns the subsequences.



And this is just a question, 
https://github.com/C4Framework/C4iOS/blob/master/C4/UI/Shape%2BCreation.swift#L98
In this method, you set path if the variant is nil, but not newPath. But you force-unwarp variable "newPath".
Isn't this a bug?
