### PR TITLE
Sets contents of imageview instead of replacing entire view

### DIFF
--- a/C4/UI/Image+Generator.swift
+++ b/C4/UI/Image+Generator.swift
@@ -37,10 +37,8 @@ extension Image {
             outputImage = outputImage.imageByApplyingTransform(translate)
             self.output = outputImage
 
-            let img = UIImage(CIImage: output)
-            let orig = self.origin
-            self.view = UIImageView(image: img)
-            self.origin = orig
+            let context = CIContext(options: nil)
+            self.view.layer.contents = context.createCGImage(output, fromRect: output.extent)
             _originalSize = Size(view.frame.size)
         } else {
             print("Failed to generate outputImage: \(__FUNCTION__)")


### PR DESCRIPTION
Previous implementation replaces the view, which is inefficient.