### PR TITLE
Updates initialization of Image(frame:) and fixes bug in Generate

### DIFF
--- a/C4/UI/Image+Generator.swift
+++ b/C4/UI/Image+Generator.swift
@@ -33,12 +33,13 @@ extension Image {
 
         if var outputImage = crop.outputImage {
             let scale = CGAffineTransformMakeScale(1, -1)
-            let translate = CGAffineTransformTranslate(scale, 0, outputImage.extent.size.height)
-            outputImage = outputImage.imageByApplyingTransform(translate)
-            self.output = outputImage
+            outputImage = outputImage.imageByApplyingTransform(scale)
+            output = outputImage
 
-            self.imageView.image = UIImage(CIImage: output)
-            _originalSize = Size(view.frame.size)
+            //Need to output a CGImage that matches the current image's extent, {0, -h, w, h}
+            let cgimg = CIContext().createCGImage(self.output, fromRect: outputImage.extent)
+            self.imageView.image = UIImage(CGImage: cgimg)
+            _originalSize = Size(outputImage.extent.size)
         } else {
             print("Failed to generate outputImage: \(#function)")
         }

--- a/C4/UI/Image.swift
+++ b/C4/UI/Image.swift
@@ -49,6 +49,10 @@ public class Image: View, NSCopying {
 
     public override init(frame: Rect) {
         super.init(frame: frame)
+        let uiimage = UIImage()
+        let imageView = ImageView(image: uiimage)
+        imageView.frame = self.view.bounds
+        self.view = imageView
     }
 
     /// Initializes a new Image using the specified filename from the bundle (i.e. your project), it will also grab images


### PR DESCRIPTION
@aleph7 I finally remembered why I had set the contents in the first place...

When creating an image from a filter like this the coordinates of the CIImage are `{0, -h, w, h}`, so setting a UIImage like this:

```
self.imageView.image = UIImage(CIImage: output)
```

Results in the image not showing up... i.e. since the original image data is placed `-h` the contents of the new UIImage are empty.